### PR TITLE
feat: allow feature switch to rustls-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ crypto-mac = "0.10"
 futures = { version = "0.3", optional = true }
 hmac = "0.10"
 rand = "0.8"
-reqwest = { version = "0.11", features = ["blocking"] }
+reqwest = { version = "0.11", features = ["blocking"], default-features = false }
 sha-1 = "0.9"
 threadpool = "1.7"
 url = "1.7"
@@ -34,5 +34,7 @@ tokio = { version = "1.1", features = ["macros"] }
 futures = "0.3"
 
 [features]
-default = ["online-tokio"]
+default = ["online-tokio", "native-tls"]
 online-tokio = ["futures"]
+rustls-tls = ["reqwest/rustls-tls"]
+native-tls = ["reqwest/native-tls"]


### PR DESCRIPTION
- Setup feature to allow crate to switch from `native-tls` to `rustls-tls`